### PR TITLE
sugestões para instruções do etl

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -11,7 +11,7 @@ conda activate remuneracao
 ```
 
 Em caso de dificuldades consulte o issue [transparencia-mg/age7#108](https://github.com/transparencia-mg/age7/issues/108).
-Pode ser necessário trocar as barras na BASH cell dde '\' para '/':
+Pode ser necessário trocar as barras na BASH cell de `\` para `/`:
 
 ````
 Andre@DESKTOP-R63LP8N MINGW64 ~/Documents/teletrabalho/dados-mg/remuneracao (master)
@@ -48,11 +48,14 @@ somente estarão disponíveis ao final do processo, portanto seus valores devem 
 
 Também serão diferentes as propriedades `source.name`, `source.path` e `source.hash` de cada elemento da propriedade `source`.
 As informações de localização (`source.path`) e integridade (`source.hash`) dos arquivos primários no google drive podem ser colhidas de forma manual, ou por meio do target `make get info`, que imprime na linha de comando os metadados relevantes extraídos do google drive. 
-Para tanto, é necessário informar o `id` da pasta no google drive que contém os arquivos relevantes. O `id` deve extraído da URL da pasta, e o comando deve ser executado
+
+Para tanto, é necessário informar o `id` da pasta no google drive que contém os arquivos relevantes. O `id` deve extraído da [URL da pasta](https://drive.google.com/drive/u/0/folders/18AdLoyizGT2_4DjBM8uyIRtidKHUOoZY), e o comando deve ser executado
 
 ```sh
 make get-info id=1dDdvkf-ku8bJTI-gEJ27JBRu7H7z1q_h
 ```
+
+OBS.: o caminho das pastas do drive onde se localizam os arquivos:  Diretoria_Transparencia_Ativa_DTA > Portal_Transparencia > Consultas > Remuneração > Produção > Planilhas_remuneracao > ANO
 
 Copie e cole as propriedades `path` e `hash` nas mesmas propriedades do novo recurso no arquivo `datapackage.json`.
 


### PR DESCRIPTION
- [x] como ativar o ambiente (avaliar uso do `pip` como alternativa, com a necessidade de modificar scripts do R);
- [x] discriminar propriedades necessárias de serem alteradas no `datapackage.json`: `hash` e `id` devem ser deletados, pois são preenchidos ao final do processo, e não antes, como `name`, `title` e `path`;
- [x] indicar o caminho para os arquivos do `source` no drive da DTA;
- [ ] acrescentar instruções para permissões do google drive (auth) para o R;
- [ ] adicionar observação para conferir os nomes dos arquivos extraídos do drive para a pasta `raw` após comando ````make extract resource=servidores-AAAA-MM````;
- [ ] adicionar instrução sobre como instalar `livemark` para comando `make validate`